### PR TITLE
Parallel computegallery versions

### DIFF
--- a/utilities/Export-AzureComputeGalleryImageVersion.ps1
+++ b/utilities/Export-AzureComputeGalleryImageVersion.ps1
@@ -65,7 +65,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$DiskPrefix = "disk-$($ImageDefinitionName)-"
+$DiskPrefix = "disk-$($ImageDefinitionName)-$($ImageVersionName)-"
 $Location = (Get-AzResourceGroup -Name $ComputeGalleryResourceGroupName).Location
 
 # Gets the Image Version ID

--- a/utilities/Export-AzureComputeGalleryImageVersion.ps1
+++ b/utilities/Export-AzureComputeGalleryImageVersion.ps1
@@ -34,10 +34,11 @@ The name of the Image Definition in the Azure Compute Gallery.
 .PARAMETER ImageVersionName
 The name of the Image Version in the Azure Compute Gallery.
 .NOTES
-  Version:              1.2
+  Version:              1.3
   Author:               Jason Masten
+  Contributors:         Philip Mallegol-Hansen
   Creation Date:        2022-05-11
-  Last Modified Date:   2023-02-05
+  Last Modified Date:   2023-03-21
 .EXAMPLE
 .\Export-AzureComputeGalleryImageVersion.ps1 `
     -ComputeGalleryName 'cg_shared_d_va' `

--- a/utilities/Import-AzureComputeGalleryImageVersion.ps1
+++ b/utilities/Import-AzureComputeGalleryImageVersion.ps1
@@ -132,7 +132,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$DiskPrefix = "disk-$($ImageDefinitionName)-"
+$DiskPrefix = "disk-$($ImageDefinitionName)-$($ImageVersionName)-"
 $Location = (Get-AzResourceGroup -Name $ComputeGalleryResourceGroupName).Location
 
 # Checks if the Compute Gallery exists
@@ -180,7 +180,7 @@ if(!$ImageDefinition)
 }
 
 # Get the downloaded disks / VHDs from the Downloads folder
-$Vhds = Get-ChildItem -Path "$($HOME)\Downloads\disk-$($ImageDefinitionName)-*.vhd"
+$Vhds = Get-ChildItem -Path "$($HOME)\Downloads\$($DiskPrefix)*.vhd"
 
 # Throw an error if the disks are not found
 if($Vhds.Count -eq 0)

--- a/utilities/Import-AzureComputeGalleryImageVersion.ps1
+++ b/utilities/Import-AzureComputeGalleryImageVersion.ps1
@@ -105,7 +105,7 @@ param(
     [parameter(Mandatory)]
     [string]$ImageDefinitionName,
 
-    [parameter(Mandatory=$false)]
+    [parameter(Mandatory)]
     [string]$ImageDefinitionOffer,
 
     [parameter(Mandatory=$false)]
@@ -116,8 +116,8 @@ param(
     [string]$ImageDefinitionPublisher,
 
     [parameter(Mandatory=$false)]
-    [ValidateSet('ConfidentialVM','ConfidentialVMSupported','Standard','TrustedLaunch')]
-    [string]$ImageDefinitionSecurityType = 'Standard',
+    [ValidateSet('ConfidentialVM','ConfidentialVMSupported','None','TrustedLaunch')]
+    [string]$ImageDefinitionSecurityType = 'None',
 
     [parameter(Mandatory=$false)]
     [string]$ImageDefinitionSku,
@@ -170,7 +170,7 @@ if(!$ImageDefinition)
         -ResourceGroupName $ComputeGalleryResourceGroupName `
         -Feature $Features `
         -HyperVGeneration $ImageDefinitionHyperVGeneration `
-        -ImageDefinitionOsType $ImageDefinitionOsType `
+        -OsType $ImageDefinitionOsType `
         -Location $Location `
         -Name $ImageDefinitionName `
         -Offer $ImageDefinitionOffer `
@@ -198,7 +198,7 @@ for($i = 0; $i -lt $Vhds.Count; $i++)
         -ResourceGroupName $ComputeGalleryResourceGroupName `
         -Location $Location `
         -DiskName ($DiskPrefix + $i.ToString()) `
-        -DiskImageDefinitionOsType $ImageDefinitionOsType `
+        -DiskOsType $ImageDefinitionOsType `
         -NumberOfUploaderThreads 32
 
     # Gets the information for the Managed Disk

--- a/utilities/Import-AzureComputeGalleryImageVersion.ps1
+++ b/utilities/Import-AzureComputeGalleryImageVersion.ps1
@@ -44,7 +44,7 @@ The operating system type for the Image Definition.
 .PARAMETER ImageDefinitionPublisher
 The publisher for the Image Defintion.
 .PARAMETER ImageDefinitionSecurityType
-The security type for the Image Definition.
+The security type for the Image Definition. Note: What Azure calls "Standard" is defined as "None" when using the Powershell Module.
 .PARAMETER ImageDefinitionSku
 The SKU for the Image Defintion.
 .PARAMETER ImageDefinitionState
@@ -52,10 +52,11 @@ The state for the Image Defintion.
 .PARAMETER ImageVersionName
 The name for the Image Version.
 .NOTES
-  Version:              1.2
+  Version:              1.3
   Author:               Jason Masten
+  Contributors:         Philip Mallegol-Hansen
   Creation Date:        2022-05-11
-  Last Modified Date:   2023-02-05
+  Last Modified Date:   2023-03-28
 .EXAMPLE
 .\Import-AzureComputeGalleryImageVersion.ps1 `
     -ComputeGalleryName 'cg_shared_d_eu' `
@@ -67,7 +68,7 @@ The name for the Image Version.
     -ImageDefinitionOffer 'WindowsServer' `
     -ImageDefinitionOsType 'Windows' `
     -ImageDefinitionPublisher 'MicrosoftWindowsServer' `
-    -ImageDefinitionSecurityType 'Standard' `
+    -ImageDefinitionSecurityType 'None' `
     -ImageDefinitionSku '2019-datacenter' `
     -ImageDefinitionState 'generalized' `
     -ImageVersionName '1.0.0'
@@ -78,6 +79,7 @@ This example imports the VHD as a Managed Disk, creates a new Image Defintion, a
     -ComputeGalleryName 'cg_shared_d_eu' `
     -ComputeGalleryResourceGroupName 'rg-images-d-eu' `
     -ImageDefinitionName 'WindowsServer2019Datacenter' `
+    -ImageDefinitionOffer 'WindowsServer' `
     -ImageVersionName '1.0.0'
 
 This example imports the VHD as a Managed Disk and imports the Managed Disk as a new Image Version into an existing Image Defintion.


### PR DESCRIPTION
I believe these changes should address the comments in #12.

I am using my own fork to complete a migration of images between tenants right now, once I confirm that it worked as intended. I will mark this as ready. 